### PR TITLE
add ID definition

### DIFF
--- a/src/gas-freshdesk-lib.js
+++ b/src/gas-freshdesk-lib.js
@@ -198,7 +198,7 @@ var GasFreshdesk = (function () {
         * 1. existing ticket, retried it by ID
         */
         
-        id = options
+        var id = options
         
         reloadTicket(id)
 


### PR DESCRIPTION
Added to stop exception regarding an undefined variable ID.
This is a quick fix and no alternatives were considered.